### PR TITLE
Add /pending_checks for conditional "NOT READY" label application

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add a webhook to your repo pointing to `http://your-app.herokuapp.com/staged` wi
 * Push
 
 ### Pending Checks Label
-This webhooks adds/removes the "`NOT READY`" label based on status check results of pull requests with the "`PENDING CHECKS`" label. If checks fail, it adds the "`NOT READY`" label. If they pass, it removes "`PENDING CHECKS`" and "`NOT READY`".
+This webhook adds/removes the "`NOT READY`" label based on status check results of pull requests with the "`PENDING CHECKS`" label. If checks fail, it adds the "`NOT READY`" label. If they pass, it removes "`PENDING CHECKS`" and "`NOT READY`".
 
 Add a webhook to your repo pointing to `http://your-app.herokuapp.com/pending_checks` with the Status event selected.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Add a webhook to your repo pointing to `http://your-app.herokuapp.com/staged` wi
 * Pull Request
 * Push
 
+### Pending Checks Label
+This webhooks adds/removes the "`NOT READY`" label based on status check results of pull requests with the "`PENDING CHECKS`" label. If checks fail, it adds the "`NOT READY`" label. If they pass, it removes "`PENDING CHECKS`" and "`NOT READY`".
+
+Add a webhook to your repo pointing to `http://your-app.herokuapp.com/pending_checks` with the Status event selected.
+
 ## Copyright & License
 
 Copyright (c) Tim Morgan, licensed MIT. See LICENSE file in this repo.

--- a/jobs/update_pending_checks_job.rb
+++ b/jobs/update_pending_checks_job.rb
@@ -1,0 +1,10 @@
+require 'sidekiq'
+require_relative '../app'
+
+class UpdatePendingChecksJob
+  include Sidekiq::Worker
+
+  def perform(payload)
+    update_pending_checks(payload)
+  end
+end


### PR DESCRIPTION
This lets you add a `PENDING CHECKS` label to a PR. This will do 1 of two things once the checks for a PR have run:
1.  on success: Remove the pending label, and the not ready label (if present)
2. on failure/error: Apply a `NOT READY` label  

The idea was to be able to open or push to a PR you _think_ is ready, without having to babysit it to ensure checks passed before marking it as ready for review. Applying the `NOT READY` label prevents PRs from being picked up by [reviewbot](https://github.com/danielma/reviewbot), and is also an obvious indicator to other humans that it is not ready for prying eyes (and that you don't need to let author know it has failed checks).

My initial plan was to also "promote" draft pull requests on successful check completion, but this feature is not available in github's APIs yet (you can you only create draft via PRs, or get their draft status 😢). 